### PR TITLE
fix supw path for murmur.x86

### DIFF
--- a/files/supw
+++ b/files/supw
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-/opt/mumble/murmur.x86/murmur.x86 -ini /etc/mumble/config.ini -readsupw
+/opt/mumble/murmur.x86 -ini /etc/mumble/config.ini -readsupw


### PR DESCRIPTION
prevent the following error: 

```
docker exec -it foobar supw
```

> /usr/local/bin/supw: line 3: /opt/mumble/murmur.x86/murmur.x86: not found
