### PR TITLE
Add docker-compose file and kickme.sh

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.7"
+version: "3.3"
 services:
   mumble-server:
     image: phlak/mumble

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.7"
+version: "3.3"
 services:
   mumble-server:
     image: phlak/mumble
@@ -6,10 +6,10 @@ services:
     environment:
       - TZ=America/New_York
     ports:
-      -64738:64738
-      -64738:64738/udp
+      - "64738:64738"
+      - "64738:64738/udp"
     volumes:
-      -mumble-data:/etc/mumble
+      - "mumble-data:/etc/mumble"
       
 volumes:
   mumble-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3.7"
+services:
+  mumble-server:
+    image: phlak/mumble
+    restart: unless-stopped
+    environment:
+      - TZ=America/New_York
+    ports:
+      -64738:64738
+      -64738:64738/udp
+    volumes:
+      -mumble-data:/etc/mumble
+      
+volumes:
+  mumble-data:

--- a/kickme.sh
+++ b/kickme.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-docker-compose down && docker-compose pull --ignore-pull-failures && docker-compose up
+docker-compose down && docker-compose pull --ignore-pull-failures && docker-compose up -d

--- a/kickme.sh
+++ b/kickme.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+docker-compose down && docker-compose pull --ignore-pull-failures && docker-compose up


### PR DESCRIPTION
## Synopsis:

For easier management of the dockerized Mumble server, added a [docker-compose](https://docs.docker.com/compose/compose-file/) file and [kickme.sh](https://github.com/mkrupczak3/kickme.sh).

### docker-compose
Easier management of launch args for running docker containers can be obtained using the docker-compose tool. The tool can be installed with "yum install docker-compose" , "apt-get install docker-compose" or equivalent. 

Single or multi-container setups can be defined in a simple YAML text file format, and brought up with "docker-compose up". All containers can be updated with "docker-compose pull" and can be brought down with "docker-compose down"

For this PR, I've added [docker-compose.yml](https://github.com/PHLAK/docker-mumble/blob/d843fd3eec069ff1a0008605e5292715ed708260/docker-compose.yml)

### kickme.sh

uses docker-compose to bring down containers, pull any new updates, and bring back up. Very useful in general.

[kickme.sh](https://github.com/mkrupczak3/kickme.sh)