### PR TITLE
Set SuperUser Password using environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN chmod +x /usr/local/bin/supw
 ARG BZIP_URL=https://github.com/mumble-voip/mumble/releases/download/${MUMBLE_VERSION}/murmur-static_x86-${MUMBLE_VERSION}.tar.bz2
 
 # Install dependencies, fetch Mumble bzip archive and chown files
-RUN apk add --update ca-certificates bash bzip2 gettext tar tzdata wget \
+RUN apk add --update ca-certificates su-exec bzip2 gettext tar tzdata wget \
     && wget -qO- ${BZIP_URL} | tar -xjv --strip-components=1 -C /opt/mumble \
     && apk del ca-certificates bzip2 tar wget && rm -rf /var/cache/apk/* \
     && chown -R mumble:mumble /etc/mumble /opt/mumble

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN chmod +x /usr/local/bin/supw
 ARG BZIP_URL=https://github.com/mumble-voip/mumble/releases/download/${MUMBLE_VERSION}/murmur-static_x86-${MUMBLE_VERSION}.tar.bz2
 
 # Install dependencies, fetch Mumble bzip archive and chown files
-RUN apk add --update ca-certificates bzip2 tar tzdata wget \
+RUN apk add --update ca-certificates bash bzip2 gettext tar tzdata wget \
     && wget -qO- ${BZIP_URL} | tar -xjv --strip-components=1 -C /opt/mumble \
     && apk del ca-certificates bzip2 tar wget && rm -rf /var/cache/apk/* \
     && chown -R mumble:mumble /etc/mumble /opt/mumble
@@ -40,4 +40,5 @@ VOLUME /etc/mumble
 
 # Entrypoint
 COPY entrypoint.sh /app/entrypoint.sh
-ENTRYPOINT /app/entrypoint.sh -fg -ini $CONFIG_PATH
+ENTRYPOINT [ "/app/entrypoint.sh" ]
+CMD [ "/opt/mumble/murmur.x86", "-fg", "-ini" , "${CONFIG_PATH}" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Chris Kankiewicz <Chris@ChrisKankiewicz.com>"
 # Define Mumble version
 ARG MUMBLE_VERSION=1.3.0
 
-ENV CONFIG_PATH=/etc/mumble/config.ini
+ENV CONFIG_PATH=/etc/mumble/config.ini \
     SUPERUSER_PASSWORD=
 
 # Create Mumble directories
@@ -40,6 +40,4 @@ VOLUME /etc/mumble
 
 # Entrypoint
 COPY entrypoint.sh /app/entrypoint.sh
-ENTRYPOINT ["/app/entrypoint.sh"]
-# Default command args
-CMD ["-fg", "-ini", "$CONFIG_PATH"]
+ENTRYPOINT /app/entrypoint.sh -fg -ini $CONFIG_PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ LABEL maintainer="Chris Kankiewicz <Chris@ChrisKankiewicz.com>"
 # Define Mumble version
 ARG MUMBLE_VERSION=1.3.0
 
+ENV CONFIG_PATH=/etc/mumble/config.ini
+    SUPERUSER_PASSWORD=
+
 # Create Mumble directories
 RUN mkdir -pv /opt/mumble /etc/mumble
 
@@ -35,5 +38,7 @@ USER mumble
 # Set volumes
 VOLUME /etc/mumble
 
-# Default command
-CMD ["/opt/mumble/murmur.x86", "-fg", "-ini", "/etc/mumble/config.ini"]
+# Entrypoint
+COPY entrypoint.sh /app/entrypoint.sh
+ENTRYPOINT ["/app/entrypoint.sh"]
+CMD ["-fg", "-ini", "$CONFIG_PATH"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN chmod +x /usr/local/bin/supw
 ARG BZIP_URL=https://github.com/mumble-voip/mumble/releases/download/${MUMBLE_VERSION}/murmur-static_x86-${MUMBLE_VERSION}.tar.bz2
 
 # Install dependencies, fetch Mumble bzip archive and chown files
-RUN apk add --update ca-certificates su-exec bzip2 gettext tar tzdata wget \
+RUN apk add --update ca-certificates bzip2 gettext tar tzdata wget \
     && wget -qO- ${BZIP_URL} | tar -xjv --strip-components=1 -C /opt/mumble \
     && apk del ca-certificates bzip2 tar wget && rm -rf /var/cache/apk/* \
     && chown -R mumble:mumble /etc/mumble /opt/mumble

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,4 +41,5 @@ VOLUME /etc/mumble
 # Entrypoint
 COPY entrypoint.sh /app/entrypoint.sh
 ENTRYPOINT ["/app/entrypoint.sh"]
+# Default command args
 CMD ["-fg", "-ini", "$CONFIG_PATH"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,7 @@ LABEL maintainer="Chris Kankiewicz <Chris@ChrisKankiewicz.com>"
 # Define Mumble version
 ARG MUMBLE_VERSION=1.3.0
 
-ENV CONFIG_PATH=/etc/mumble/config.ini \
-    SUPERUSER_PASSWORD=
+ENV CONFIG_PATH=/etc/mumble/config.ini
 
 # Create Mumble directories
 RUN mkdir -pv /opt/mumble /etc/mumble

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ After the data volume has been created run the server container with the named d
 
 #### Optional 'docker run' arguments
 
+`-e SUPERUSER_PASSWORD=password` - Set the superuser password for your server during container initialization.
+
 `-e TZ=America/Phoenix` - Set the timezone for your server. You can find your timezone in this
                           [list of timezones](https://goo.gl/uy1J6q). Use the (case sensitive)
                           value from the `TZ` column. If left unset, timezone will be UTC.
@@ -56,17 +58,7 @@ After starting your container, you can get the randomly generated SuperUser pass
 
 **--- OR ---**
 
-Provide a SuperUser password using the `SUPERUSER_PASSWORD` environment variable:
-
-```
-    docker run -d \
-      -e SUPERUSER_PASSWORD=mysupersecurepassword
-      -p 64738:64738 \
-      -p 64738:64738/udp \
-      -v mumble-data:/etc/mumble \
-      --name mumble-server \
-      phlak/mumble
-```
+Provide a SuperUser password using the `SUPERUSER_PASSWORD` environment variable, see [Optional arguments section](#optional-docker-run-arguments).
 
 **--- OR ---**
 

--- a/README.md
+++ b/README.md
@@ -28,12 +28,7 @@ volume. This is not required but is _highly_ recommended.
 
 After the data volume has been created run the server container with the named data volume:
 
-    docker run -d \
-      -p 64738:64738 \
-      -p 64738:64738/udp \
-      -v mumble-data:/etc/mumble \
-      --name mumble-server \
-      phlak/mumble
+    docker run -d -p 64738:64738 -p 64738:64738/udp -v mumble-data:/etc/mumble --name mumble-server phlak/mumble
 
 
 #### Optional 'docker run' arguments

--- a/README.md
+++ b/README.md
@@ -28,7 +28,12 @@ volume. This is not required but is _highly_ recommended.
 
 After the data volume has been created run the server container with the named data volume:
 
-    docker run -d -p 64738:64738 -p 64738:64738/udp -v mumble-data:/etc/mumble --name mumble-server phlak/mumble
+    docker run -d \
+      -p 64738:64738 \
+      -p 64738:64738/udp \
+      -v mumble-data:/etc/mumble \
+      --name mumble-server \
+      phlak/mumble
 
 
 #### Optional 'docker run' arguments
@@ -48,6 +53,20 @@ Get/Set the SuperUser Password
 After starting your container, you can get the randomly generated SuperUser password with:
 
     docker logs mumble-server 2>&1 | grep "Password for 'SuperUser'"
+
+**--- OR ---**
+
+Provide a SuperUser password using the `SUPERUSER_PASSWORD` environment variable:
+
+```
+    docker run -d \
+      -e SUPERUSER_PASSWORD=mysupersecurepassword
+      -p 64738:64738 \
+      -p 64738:64738/udp \
+      -v mumble-data:/etc/mumble \
+      --name mumble-server \
+      phlak/mumble
+```
 
 **--- OR ---**
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if [[ ! "$SUPERUSER_PASSWORD" == "" ]]; then
+    /opt/mumble/murmur.x86 -fg -init $CONFIG_PATH -supw $SUPERUSER_PASSWORD
+    echo "SuperUser password set to '$SUPERUSER_PASSWORD'"
+    unset SUPERUSER_PASSWORD
+fi
+
+/opt/mumble/murmur.x86 "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 if [[ ! "$SUPERUSER_PASSWORD" == "" ]]; then
     /opt/mumble/murmur.x86 -fg -ini $CONFIG_PATH -supw $SUPERUSER_PASSWORD
-    echo "SuperUser password set from environment variable"
+    echo "Password for 'SuperUser' was set from environment variable"
     unset SUPERUSER_PASSWORD
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,9 @@
-#!/bin/sh
+#!/bin/bash
 
-if [[ ! "$SUPERUSER_PASSWORD" == "" ]]; then
-    /opt/mumble/murmur.x86 -fg -ini $CONFIG_PATH -supw $SUPERUSER_PASSWORD
+if [[ ! "${SUPERUSER_PASSWORD}" == "" ]]; then
+    /opt/mumble/murmur.x86 -fg -ini ${CONFIG_PATH} -supw ${SUPERUSER_PASSWORD}
     echo "Password for 'SuperUser' was set from environment variable"
     unset SUPERUSER_PASSWORD
 fi
 
-/opt/mumble/murmur.x86 "$@"
+exec $(echo "$@" | envsubst)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [[ ! "${SUPERUSER_PASSWORD}" == "" ]]; then
-    /opt/mumble/murmur.x86 -fg -ini ${CONFIG_PATH} -supw ${SUPERUSER_PASSWORD}
+    /opt/mumble/murmur.x86 -ini ${CONFIG_PATH} -supw ${SUPERUSER_PASSWORD}
     echo "Password for 'SuperUser' was set from environment variable"
     unset SUPERUSER_PASSWORD
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 if [[ ! "${SUPERUSER_PASSWORD}" == "" ]]; then
     /opt/mumble/murmur.x86 -fg -ini ${CONFIG_PATH} -supw ${SUPERUSER_PASSWORD}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 if [[ ! "$SUPERUSER_PASSWORD" == "" ]]; then
     /opt/mumble/murmur.x86 -fg -ini $CONFIG_PATH -supw $SUPERUSER_PASSWORD
-    echo "SuperUser password set to '$SUPERUSER_PASSWORD'"
+    echo "SuperUser password set from environment variable"
     unset SUPERUSER_PASSWORD
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [[ ! "$SUPERUSER_PASSWORD" == "" ]]; then
-    /opt/mumble/murmur.x86 -fg -init $CONFIG_PATH -supw $SUPERUSER_PASSWORD
+    /opt/mumble/murmur.x86 -fg -ini $CONFIG_PATH -supw $SUPERUSER_PASSWORD
     echo "SuperUser password set to '$SUPERUSER_PASSWORD'"
     unset SUPERUSER_PASSWORD
 fi


### PR DESCRIPTION
Hey there, great stuff!

I use your image to run murmur inside a Kubernetes cluster. For that it is handy to be able to provide configuration though environment variables, so I added the ability to set the SuperUser password using an `SUPERUSER_PASSWORD` environment variable.

I also added an env variable `CONFIG_PATH`. With that it would be possible to set an arbitrary config file path if desired, but since that wouldn't work with the default configuration I **did not** add this to the README. If a user mounts the `config.ini` file from the host system it would be possible to use a different path (whatever that brings to the table). The main reason I added this env var was to use it in multiple places respecting the DRY principle.

I also moved the main "command" to the `Entrypoint` directive, since thats how it is supposed to be. Technically all murmur arguments would stay in the `CMD` directive, but I couldn't find a nice way to use the ENV var, `ENTRYPOINT` and `CMD` directives in conjunction, so I put them all into the entrypoint.

Thx for your work! :+1: 